### PR TITLE
Add CloudFront invalidation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,27 @@ deploy:
 
 And then deploy using `hexo deploy`.
 
+### CloudFront Invalidation
+
+After deploying to S3 the plugin can optionally invalidate a CloudFront distribution to force a cache refresh. To do
+this, add the CloudFront distribution ID to your Hexo config:
+
+```yaml
+deploy:
+  type: aws-s3
+  region: us-east-1
+  bucket: example-bucket
+  cloudfront_distribution: EXAMPLE123
+```
+
 ## Options
 
-| Name             | Default    | Description                                                          |
-|------------------|------------|----------------------------------------------------------------------|
-| `region`         | _required_ | AWS region that the bucket is hosted in.                             |
-| `bucket`         | _required_ | AWS bucket to upload to.                                             | 
-| `profile`        | `default`  | AWS credentials profile to use (see [Named Profiles][aws-profiles]). |
-| `delete_unknown` | `false`    | If `true` then any unknown files will be deleted from the bucket.    |
+| Name                      | Default    | Description                                                          |
+|---------------------------|------------|----------------------------------------------------------------------|
+| `region`                  | _required_ | AWS region that the bucket is hosted in.                             |
+| `bucket`                  | _required_ | AWS bucket to upload to.                                             | 
+| `profile`                 | `default`  | AWS credentials profile to use (see [Named Profiles][aws-profiles]). |
+| `delete_unknown`          | `false`    | If `true` then any unknown files will be deleted from the bucket.    |
+| `cloudfront_distribution` | _none_     | CloudFront distribution ID to invalidate on deploy.                  |
 
 [aws-profiles]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

--- a/lib/aws-cloudfront.js
+++ b/lib/aws-cloudfront.js
@@ -1,0 +1,41 @@
+const {
+  CloudFrontClient,
+  CreateInvalidationCommand,
+} = require('@aws-sdk/client-cloudfront');
+const { fromIni } = require('@aws-sdk/credential-provider-ini');
+
+class CloudFrontInvalidator {
+  constructor(args) {
+    const profile = args.profile || 'default';
+
+    this.distribution = args.cloudfront_distribution;
+
+    this.client = new CloudFrontClient({
+      region: args.region,
+      credentials: fromIni({ profile }),
+    });
+  }
+
+  async invalidateDistribution() {
+    console.log(`Invalidating CloudFront distribution ${this.distribution}`);
+
+    const reference = new Date().toISOString();
+
+    const invalidateRequest = new CreateInvalidationCommand({
+      DistributionId: this.distribution,
+      InvalidationBatch: {
+        CallerReference: reference,
+        Paths: {
+          Items: ['/*'],
+          Quantity: 1,
+        },
+      },
+    });
+
+    await this.client.send(invalidateRequest);
+  }
+}
+
+module.exports = {
+  CloudFrontInvalidator: CloudFrontInvalidator,
+};

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -8,6 +8,7 @@ const { fromIni } = require('@aws-sdk/credential-provider-ini');
 const fs = require('fs');
 const path = require('path');
 const mime = require('mime');
+const { CloudFrontInvalidator } = require('./aws-cloudfront');
 
 class S3Deployer {
   constructor(args) {
@@ -78,7 +79,7 @@ class S3Deployer {
       Bucket: this.bucket,
       Key: key,
       Body: fs.createReadStream(file),
-      ContentType: mimeType
+      ContentType: mimeType,
     });
 
     await this.client.send(request);
@@ -96,5 +97,10 @@ module.exports = async function (hexo, args) {
 
   if (args.delete_unknown) {
     await deployer.deleteUnknown(keys);
+  }
+
+  if (args.cloudfront_distribution) {
+    const invalidator = new CloudFrontInvalidator(args);
+    await invalidator.invalidateDistribution();
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-cloudfront": "^3.48.0",
         "@aws-sdk/client-s3": "^3.48.0",
         "@aws-sdk/credential-provider-ini": "^3.48.0",
         "mime": "^3.0.0"
@@ -144,6 +145,53 @@
       "dependencies": {
         "@aws-sdk/util-base64-browser": "3.47.1",
         "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.48.0.tgz",
+      "integrity": "sha512-JiHERICwhT5IjoSfdAOpWEAGphYt5nWwovQyR+o50BQ+M0JmPltU9y91dVVhbYbYQjFX2J+bwrJhrodhOQZkUw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.48.0",
+        "@aws-sdk/config-resolver": "3.47.2",
+        "@aws-sdk/credential-provider-node": "3.48.0",
+        "@aws-sdk/fetch-http-handler": "3.47.2",
+        "@aws-sdk/hash-node": "3.47.2",
+        "@aws-sdk/invalid-dependency": "3.47.2",
+        "@aws-sdk/middleware-content-length": "3.47.2",
+        "@aws-sdk/middleware-host-header": "3.47.2",
+        "@aws-sdk/middleware-logger": "3.47.2",
+        "@aws-sdk/middleware-retry": "3.47.2",
+        "@aws-sdk/middleware-serde": "3.47.2",
+        "@aws-sdk/middleware-signing": "3.47.2",
+        "@aws-sdk/middleware-stack": "3.47.2",
+        "@aws-sdk/middleware-user-agent": "3.47.2",
+        "@aws-sdk/node-config-provider": "3.47.2",
+        "@aws-sdk/node-http-handler": "3.47.2",
+        "@aws-sdk/protocol-http": "3.47.2",
+        "@aws-sdk/smithy-client": "3.47.2",
+        "@aws-sdk/types": "3.47.1",
+        "@aws-sdk/url-parser": "3.47.2",
+        "@aws-sdk/util-base64-browser": "3.47.1",
+        "@aws-sdk/util-base64-node": "3.47.2",
+        "@aws-sdk/util-body-length-browser": "3.47.1",
+        "@aws-sdk/util-body-length-node": "3.47.1",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+        "@aws-sdk/util-defaults-mode-node": "3.47.2",
+        "@aws-sdk/util-user-agent-browser": "3.47.2",
+        "@aws-sdk/util-user-agent-node": "3.47.2",
+        "@aws-sdk/util-utf8-browser": "3.47.1",
+        "@aws-sdk/util-utf8-node": "3.47.2",
+        "@aws-sdk/util-waiter": "3.47.2",
+        "@aws-sdk/xml-builder": "3.47.1",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -8067,6 +8115,50 @@
       "integrity": "sha512-29+ZWESaFDQ9QXo7RGcUMuP89GTKo8bKlYplzNsO/B1uG17LgTgVHBapU3UBlF/EkOh1rzN5tEW+XwwstHvlXg==",
       "requires": {
         "@aws-sdk/util-base64-browser": "3.47.1",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-cloudfront": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.48.0.tgz",
+      "integrity": "sha512-JiHERICwhT5IjoSfdAOpWEAGphYt5nWwovQyR+o50BQ+M0JmPltU9y91dVVhbYbYQjFX2J+bwrJhrodhOQZkUw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.48.0",
+        "@aws-sdk/config-resolver": "3.47.2",
+        "@aws-sdk/credential-provider-node": "3.48.0",
+        "@aws-sdk/fetch-http-handler": "3.47.2",
+        "@aws-sdk/hash-node": "3.47.2",
+        "@aws-sdk/invalid-dependency": "3.47.2",
+        "@aws-sdk/middleware-content-length": "3.47.2",
+        "@aws-sdk/middleware-host-header": "3.47.2",
+        "@aws-sdk/middleware-logger": "3.47.2",
+        "@aws-sdk/middleware-retry": "3.47.2",
+        "@aws-sdk/middleware-serde": "3.47.2",
+        "@aws-sdk/middleware-signing": "3.47.2",
+        "@aws-sdk/middleware-stack": "3.47.2",
+        "@aws-sdk/middleware-user-agent": "3.47.2",
+        "@aws-sdk/node-config-provider": "3.47.2",
+        "@aws-sdk/node-http-handler": "3.47.2",
+        "@aws-sdk/protocol-http": "3.47.2",
+        "@aws-sdk/smithy-client": "3.47.2",
+        "@aws-sdk/types": "3.47.1",
+        "@aws-sdk/url-parser": "3.47.2",
+        "@aws-sdk/util-base64-browser": "3.47.1",
+        "@aws-sdk/util-base64-node": "3.47.2",
+        "@aws-sdk/util-body-length-browser": "3.47.1",
+        "@aws-sdk/util-body-length-node": "3.47.1",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.2",
+        "@aws-sdk/util-defaults-mode-node": "3.47.2",
+        "@aws-sdk/util-user-agent-browser": "3.47.2",
+        "@aws-sdk/util-user-agent-node": "3.47.2",
+        "@aws-sdk/util-utf8-browser": "3.47.1",
+        "@aws-sdk/util-utf8-node": "3.47.2",
+        "@aws-sdk/util-waiter": "3.47.2",
+        "@aws-sdk/xml-builder": "3.47.1",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prettier": "^2.5.1"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudfront": "^3.48.0",
     "@aws-sdk/client-s3": "^3.48.0",
     "@aws-sdk/credential-provider-ini": "^3.48.0",
     "mime": "^3.0.0"


### PR DESCRIPTION
This adds a new config option (`cloudfront_distribution`) that if set will create a CloudFront invalidation after deploying to S3.

Resolves #1