### PR TITLE
Auto-generate S3 website redirect rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,55 @@ deploy:
   cloudfront_distribution: EXAMPLE123
 ```
 
+### Redirect Rules
+
+Adding S3 [webpage redirects][s3-redirects] is supported via entries in the Hexo config and via page front-matter.
+
+:warning: Any existing webpage redirects configured for the S3 bucket will get overwritten by the redirects generated
+by this plugin.
+
+#### Via Front-Matter
+
+With a `permalink` setting of `:year/:month/:day/:title/` and the following front-matter:
+
+```yaml
+---
+title: Exciting Post
+date: 2022-01-01 12:00:00
+redirect_from: old-path.html
+---
+```
+
+A redirect from `old-path.html` to `2022/01/01/exciting-post` will be generated.  
+
+#### Via Config
+
+Additionally, redirects can be specified directly in the Hexo config: 
+
+```yaml
+deploy:
+  type: aws-s3
+  redirects:
+    'old.html': 'new-post'
+    'another.html': 'pages/something/new'
+```
+
+Will generate the following redirects:
+
+- `old.html` to `new-post`.
+- `another.html` to `pages/something/new`.
+
 ## Options
 
-| Name                      | Default    | Description                                                          |
-|---------------------------|------------|----------------------------------------------------------------------|
-| `region`                  | _required_ | AWS region that the bucket is hosted in.                             |
-| `bucket`                  | _required_ | AWS bucket to upload to.                                             | 
-| `profile`                 | `default`  | AWS credentials profile to use (see [Named Profiles][aws-profiles]). |
-| `delete_unknown`          | `false`    | If `true` then any unknown files will be deleted from the bucket.    |
-| `cloudfront_distribution` | _none_     | CloudFront distribution ID to invalidate on deploy.                  |
+| Name                      | Default    | Description                                                                           |
+|---------------------------|------------|---------------------------------------------------------------------------------------|
+| `region`                  | _required_ | AWS region that the bucket is hosted in.                                              |
+| `bucket`                  | _required_ | AWS bucket to upload to.                                                              | 
+| `profile`                 | `default`  | AWS credentials profile to use (see [Named Profiles][aws-profiles]).                  |
+| `delete_unknown`          | `false`    | If `true` then any unknown files will be deleted from the bucket.                     |
+| `cloudfront_distribution` | _none_     | CloudFront distribution ID to invalidate on deploy.                                   |
+| `redirects`               | _none_     | Mappings of from path → destination path that will get converted into redirect rules. |
+| `host_name`               | _none_     | Domain name of the S3 website that will be used for redirects.                        |
 
 [aws-profiles]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+[s3-redirects]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-page-redirect.html

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -3,6 +3,8 @@ const {
   ListObjectsCommand,
   PutObjectCommand,
   DeleteObjectsCommand,
+  GetBucketWebsiteCommand,
+  PutBucketWebsiteCommand,
 } = require('@aws-sdk/client-s3');
 const { fromIni } = require('@aws-sdk/credential-provider-ini');
 const fs = require('fs');
@@ -11,8 +13,13 @@ const mime = require('mime');
 const { CloudFrontInvalidator } = require('./aws-cloudfront');
 
 class S3Deployer {
-  constructor(args) {
+  /**
+   * @param {Hexo} hexo
+   * @param args
+   */
+  constructor(hexo, args) {
     // TODO validate args
+    this.hexo = hexo;
     this.bucket = args.bucket;
 
     const profile = args.profile || 'default';
@@ -40,7 +47,6 @@ class S3Deployer {
     const unknownKeys = bucketKeys
       .filter((key) => !knownKeys.includes(key))
       .map((key) => {
-        console.log(`Deleting ${key}`);
         return { Key: key };
       });
 
@@ -56,6 +62,83 @@ class S3Deployer {
 
       await this.client.send(deleteRequest);
     }
+  }
+
+  async updateRedirectRules(redirects, hostName) {
+    console.log(`Applying ${redirects.length} redirect rules`);
+
+    // fetch the existing config, so we can repopulate index & error document settings
+    const getRequest = new GetBucketWebsiteCommand({ Bucket: this.bucket });
+    const getResponse = await this.client.send(getRequest);
+
+    const IndexDocument = getResponse.IndexDocument;
+    const ErrorDocument = getResponse.ErrorDocument;
+
+    // create the redirect rules in the right format
+    const redirectRules = redirects.map((redirect) => {
+      return {
+        Condition: {
+          KeyPrefixEquals: redirect.from,
+        },
+        Redirect: {
+          ReplaceKeyWith: redirect.to,
+          HostName: hostName,
+        },
+      };
+    });
+
+    // update the configuration
+    const putRequest = new PutBucketWebsiteCommand({
+      Bucket: this.bucket,
+      WebsiteConfiguration: {
+        IndexDocument,
+        ErrorDocument,
+        RoutingRules: redirectRules,
+      },
+    });
+
+    await this.client.send(putRequest);
+  }
+
+  async findRedirects() {
+    const configRedirects = this._extractConfigRedirects();
+    const postRedirects = await this._scanPostRedirects();
+
+    return [...configRedirects, ...postRedirects];
+  }
+
+  _extractConfigRedirects() {
+    const redirectConfig = this.hexo.config.deploy.redirects;
+
+    if (!redirectConfig) {
+      return [];
+    }
+
+    return Object.entries(redirectConfig).map((entry) => {
+      const [from, to] = entry;
+
+      return { from, to };
+    });
+  }
+
+  async _scanPostRedirects() {
+    // ensure that the db is loaded
+    await this.hexo.load();
+    const posts = this.hexo.model('Post').toArray();
+
+    return posts
+      .filter((post) => post.redirect_from)
+      .flatMap((post) => {
+        let fromPaths = post.redirect_from;
+
+        if (!Array.isArray(fromPaths)) {
+          fromPaths = [fromPaths];
+        }
+
+        return fromPaths.map((from) => {
+          return { from, to: post.path };
+        });
+      });
   }
 
   async _findFiles(dir) {
@@ -90,13 +173,24 @@ class S3Deployer {
   }
 }
 
+/**
+ * @param {Hexo} hexo
+ * @param args
+ * @return {Promise<void>}
+ */
 module.exports = async function (hexo, args) {
-  const deployer = new S3Deployer(args);
+  const deployer = new S3Deployer(hexo, args);
 
   const keys = await deployer.uploadDir(hexo.public_dir);
 
   if (args.delete_unknown) {
     await deployer.deleteUnknown(keys);
+  }
+
+  const redirects = await deployer.findRedirects();
+
+  if (redirects.length) {
+    await deployer.updateRedirectRules(redirects, args.host_name);
   }
 
   if (args.cloudfront_distribution) {

--- a/lib/aws-s3.js
+++ b/lib/aws-s3.js
@@ -127,7 +127,11 @@ class S3Deployer {
     const posts = this.hexo.model('Post').toArray();
 
     return posts
-      .filter((post) => post.redirect_from)
+      .filter(
+        (post) =>
+          post.redirect_from &&
+          (post.published || this.hexo.config.render_drafts),
+      )
       .flatMap((post) => {
         let fromPaths = post.redirect_from;
 


### PR DESCRIPTION
This adds the ability to define redirect rules in front-matter and `_config.yml` and have them applied to the S3 bucket.

Resolves #3 